### PR TITLE
make it possible to put fuzz tests in the test src dir

### DIFF
--- a/tribblecore/src/main/scala/org/catapult/sa/tribble/CoverageMemoryClassLoader.scala
+++ b/tribblecore/src/main/scala/org/catapult/sa/tribble/CoverageMemoryClassLoader.scala
@@ -132,7 +132,11 @@ class CoverageMemoryClassLoader(val parent : ClassLoader) extends ClassLoader(pa
 
 object CoverageMemoryClassLoader {
   def getClassStream(name : String, parent : ClassLoader) : InputStream = {
-    val res = name.replace('.', '/') + ".class"
-    parent.getResourceAsStream(res)
+    val res =  name.replace('.', '/') + ".class"
+    val result = parent.getResourceAsStream(res)
+    if (result == null) {
+      throw new IllegalArgumentException("Can not find class " + res)
+    }
+    result
   }
 }

--- a/tribblemavenplugin/src/main/java/org/catapult/sa/TribblePlugin.java
+++ b/tribblemavenplugin/src/main/java/org/catapult/sa/TribblePlugin.java
@@ -25,7 +25,7 @@ import java.util.List;
         defaultPhase = LifecyclePhase.TEST,
         requiresDependencyCollection = ResolutionScope.TEST,
         requiresDependencyResolution = ResolutionScope.TEST)
-@Execute(phase = LifecyclePhase.PACKAGE)
+@Execute(phase = LifecyclePhase.TEST_COMPILE)
 public class TribblePlugin extends AbstractMojo {
 
     @Parameter(property = "fuzztest.target", required = true)
@@ -47,12 +47,13 @@ public class TribblePlugin extends AbstractMojo {
                 realm = world.newRealm("plugin.tribble.container", this.getClass().getClassLoader());
             }
             ClassRealm projectRealm = realm.createChildRealm("theproject");
-            String output =  project.getBuild().getOutputDirectory();
-            projectRealm.addURL(new File(output).toURI().toURL());
+
+            String outputDir =  project.getBuild().getOutputDirectory();
+            String testDir = project.getBuild().getTestOutputDirectory();
+            projectRealm.addURL(new File(outputDir).toURI().toURL());
+            projectRealm.addURL(new File(testDir).toURI().toURL());
 
             Thread.currentThread().setContextClassLoader(projectRealm);
-
-            getLog().info( "Hello, world." );
 
             String[] args = {"--targetClass", target};
 


### PR DESCRIPTION
This change adds the testoutput dir to the classpath of the plugin which allows fuzz tests to be kept in the src test dir and have the tribble-core dependency in test scope.