### PR TITLE
count timeouts in stats

### DIFF
--- a/tribblecore/src/main/scala/org/catapult/sa/tribble/Corpus.scala
+++ b/tribblecore/src/main/scala/org/catapult/sa/tribble/Corpus.scala
@@ -70,7 +70,11 @@ object Corpus {
   def saveResult(input: Array[Byte], success: Boolean, ex: Option[Throwable], corpusPath : String, failedPath : String): Unit = {
 
     val md5 = MessageDigest.getInstance("MD5")
-    val filename = if(input == null) "null" else DatatypeConverter.printHexBinary(md5.digest(input))
+    val filename = if(!success) {
+      DatatypeConverter.printBase64Binary(md5.digest(ex.map(_.toString).getOrElse("").getBytes(StandardCharsets.UTF_8)))
+    } else {
+      DatatypeConverter.printHexBinary(md5.digest(input))
+    }
 
     if (!success) { // failed, record it in the crashers. But don't keep it for mutations.
       Corpus.saveArray(input, s"$failedPath/$filename.failed")

--- a/tribblecore/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
+++ b/tribblecore/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
@@ -109,7 +109,10 @@ class Fuzzer(corpusPath : String = "corpus",
           memoryClassLoader = newMemoryClassLoader
           targetClass = newTargetClass
         }
+
       }
+
+      val wasTimeout = ex.exists(_.isInstanceOf[TimeoutException])
 
       if (!coverageSet.containsKey(hash)) {
         coverageSet.put(hash, obj)
@@ -119,9 +122,9 @@ class Fuzzer(corpusPath : String = "corpus",
           val newInput = Corpus.mutate(old, rand)
           workQueue.put(newInput)
         }
-        stats.addRun(success = result, newPath = true, totalTime)
+        stats.addRun(success = result, timeout = wasTimeout, newPath = true, totalTime)
       } else {
-        stats.addRun(success = result, newPath = false, totalTime)
+        stats.addRun(success = result, timeout = wasTimeout, newPath = false, totalTime)
       }
     }
 

--- a/tribblecore/src/main/scala/org/catapult/sa/tribble/Stats.scala
+++ b/tribblecore/src/main/scala/org/catapult/sa/tribble/Stats.scala
@@ -11,15 +11,20 @@ class Stats {
 
   private val runs  = new AtomicLong(0)
   private val fails = new AtomicLong(0)
+  private val timeouts = new AtomicLong(0)
   private val paths = new AtomicInteger(0)
   private val totalTime = new AtomicLong(0)
   private val minTime = new AtomicLong(Long.MaxValue)
   private val maxTime = new AtomicLong(Long.MinValue)
 
-  def addRun(success : Boolean, newPath : Boolean, time : Long): Unit = {
+  def addRun(success : Boolean, timeout: Boolean, newPath : Boolean, time : Long): Unit = {
     runs.incrementAndGet()
     if (!success) {
-      fails.incrementAndGet()
+      if (timeout) {
+        timeouts.incrementAndGet()
+      } else {
+        fails.incrementAndGet()
+      }
     }
 
     if (newPath) {
@@ -54,11 +59,11 @@ class Stats {
     val tt = totalTime.get()
     val r = runs.get()
     val avg = if (r == 0) 0 else tt/r
-    CurrentStats(r, fails.get(), paths.get(), tt, avg, minTime.get(), maxTime.get())
+    CurrentStats(r, fails.get(), timeouts.get(), paths.get(), tt, avg, minTime.get(), maxTime.get())
   }
 
 }
 
-case class CurrentStats(runs : Long, fails : Long, paths : Int, totalTime : Long, averageTime : Long, minTime : Long, maxTime : Long) {
-  override def toString: String = s"runs: $runs fails: $fails paths: $paths total time: $totalTime average time: $averageTime min time: $minTime max time: $maxTime"
+case class CurrentStats(runs : Long, fails : Long, timeouts : Long, paths : Int, totalTime : Long, averageTime : Long, minTime : Long, maxTime : Long) {
+  override def toString: String = s"runs: $runs fails: $fails timeouts: $timeouts paths: $paths total time: $totalTime average time: $averageTime min time: $minTime max time: $maxTime"
 }


### PR DESCRIPTION
Count timeouts in the stats.
Also use stacktrace hash for filename in failed runs, this should minimize the amount of failed outputs generated.