### PR TITLE
scala-2.11 and expose ignore class option from classloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ command line.
 | threads | --threads | Number of threads to use | 2 |
 | timeout | --timeout | Time out for an individual test run in milliseconds | 1000 |
 | count | --count | number of iterations to run. Number greater than zero for a limit | -1 |
+| ignoreClasses | | List of class prefixes e.g `org.apache.hadoop.` to ignore from coverage. This is useful if you find some classes are already loaded. | |
+| | --ignoreClasses | Comma Seperated list of class prefixes to ignore.  e.g `org.apache.hadoop.` 
 
 ## Where next?
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 group 'org.catapult.sa'
 version '0.5-SNAPSHOT'
 
-ext.scalaVersion = '2.12.1'
+ext.scalaVersion = '2.11.7'

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/App.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/App.scala
@@ -12,6 +12,8 @@ object App extends Arguments {
   private val CORPUS = "corpus"
   private val FAILED = "failed"
   private val COUNT = "count"
+  private val IGNORECLASSES = "ignore"
+
 
   override def allowedArgs(): List[Argument] = List(
     Argument(CORPUS, "corpus"),
@@ -19,7 +21,8 @@ object App extends Arguments {
     Argument(THREAD_COUNT, "2"),
     Argument(TIMEOUT, "1000"),
     Argument(COUNT, "-1"),
-    Argument(TARGET_CLASS)
+    Argument(TARGET_CLASS),
+    Argument(IGNORECLASSES)
   )
 
   def main(args : Array[String]) : Unit = {
@@ -54,6 +57,7 @@ object App extends Arguments {
     val fuzzer = new Fuzzer(
       arguments(CORPUS),
       arguments(FAILED),
+      arguments(IGNORECLASSES).split(","),
       arguments(THREAD_COUNT).toInt,
       arguments(TIMEOUT).toLong,
       arguments(COUNT).toLong

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/Corpus.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/Corpus.scala
@@ -5,10 +5,11 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.security.MessageDigest
 import java.util.concurrent.BlockingQueue
-import java.util.function.Consumer
 import javax.xml.bind.DatatypeConverter
 
 import org.apache.commons.io.IOUtils
+
+import scala.collection.JavaConverters._
 
 /**
   * Functions for dealing with the corpus of inputs and mutating them.
@@ -52,7 +53,7 @@ object Corpus {
   def readCorpusInputStack(corpusPath : String, stack: BlockingQueue[Array[Byte]]): Unit = {
     lock.synchronized {
       if (stack.isEmpty) { // don't write it twice.
-        Files.newDirectoryStream(Paths.get(corpusPath)).forEach (((f : Path) => {
+        Files.newDirectoryStream(Paths.get(corpusPath)).asScala.foreach((f : Path) => {
           val stream = new FileInputStream(f.toFile)
           if (f.getFileName.endsWith(".hex")) {
             val hexString = IOUtils.toString(stream, StandardCharsets.UTF_8)
@@ -61,9 +62,8 @@ object Corpus {
             stack.put(IOUtils.toByteArray(stream))
           }
           IOUtils.closeQuietly(stream)
-        }
-      ).asInstanceOf[Consumer[Path]])
-    }
+        })
+      }
     }
   }
 

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/CoverageMemoryClassLoader.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/CoverageMemoryClassLoader.scala
@@ -64,7 +64,7 @@ class CoverageMemoryClassLoader(val parent : ClassLoader) extends ClassLoader(pa
     } else {
       // we cant override the stuff in java. So don't try to instrument
       // Strange things happen if we try and instrument our selves. Don't
-      if (!ignores.exists(name.startsWith)) {
+      if (shouldTryLoading(name)) {
         val instrumented = addClass(name)
         val result = defineClass(name, instrumented, 0, instrumented.length)
         definitionClasses.put(name, result)
@@ -72,6 +72,14 @@ class CoverageMemoryClassLoader(val parent : ClassLoader) extends ClassLoader(pa
       } else {
         super.loadClass(name, resolve)
       }
+    }
+  }
+
+  private def shouldTryLoading(name : String) : Boolean = {
+    if (name.contains(".")) { // possibly a full path check our list of ignores
+      !ignores.exists(name.startsWith)
+    } else { // not a full path if might be something like String so we should not try and load.
+      false
     }
   }
 

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
@@ -4,6 +4,8 @@ import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicLong
 
+import org.apache.commons.lang.StringUtils
+
 import scala.collection.JavaConverters._
 import scala.collection.convert.WrapAsScala.asScalaBuffer
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -16,6 +18,7 @@ import scala.util.Random
   */
 class Fuzzer(corpusPath : String = "corpus",
              failedPath : String = "failed",
+             ignoreClasses : Array[String] = Array(),
              threadCount : Int = 2,
              timeout : Long = 1000L,
              iterationCount : Long = -1) {
@@ -183,7 +186,9 @@ class Fuzzer(corpusPath : String = "corpus",
   private def createClassLoader[T <: FuzzTest](targetName : String) : (CoverageMemoryClassLoader, Class[T]) = {
     val memoryClassLoader = new CoverageMemoryClassLoader(Thread.currentThread().getContextClassLoader)
 
+    ignoreClasses.filter(StringUtils.isNotBlank).foreach(memoryClassLoader.addFilter)
     memoryClassLoader.addClass(targetName)
+
     val targetClass = memoryClassLoader.loadClass(targetName).asInstanceOf[Class[T]]
 
     Thread.currentThread().setContextClassLoader(memoryClassLoader)

--- a/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
+++ b/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
@@ -41,6 +41,9 @@ public class TribblePlugin extends AbstractMojo {
     @Parameter(property = "fuzztest.count", required = true, defaultValue = "-1")
     public long count;
 
+    @Parameter(property = "fuzztest.ignoreClasses")
+    public String[] ignoreClasses;
+
 
     @Parameter( defaultValue="${project}", required = true, readonly = true)
     public MavenProject project;
@@ -72,7 +75,7 @@ public class TribblePlugin extends AbstractMojo {
 
             Thread.currentThread().setContextClassLoader(projectRealm);
 
-            Fuzzer fuzzer = new Fuzzer(corpusPath, failedPath, threads, timeout, count);
+            Fuzzer fuzzer = new Fuzzer(corpusPath, failedPath, ignoreClasses, threads, timeout, count);
             fuzzer.run(target, projectRealm);
 
         } catch (DuplicateRealmException | MalformedURLException e) {


### PR DESCRIPTION
* Added parameter for adding classes that should not be checked for coverage.
* Fixed attempt to load String with coverage.
* Changed scala version to 2.11.7  

Found most of these changes while getting a fuzz test of the Geomesa-nifi project working.