### PR TITLE
fix 46 swap test result to enum and handle

### DIFF
--- a/tribble-core/src/main/java/org/catapult/sa/tribble/FuzzResult.java
+++ b/tribble-core/src/main/java/org/catapult/sa/tribble/FuzzResult.java
@@ -1,0 +1,15 @@
+package org.catapult.sa.tribble;
+
+/**
+ * Return value of a fuzz test
+ */
+public enum FuzzResult {
+    OK, // Fuzz test was not a failure and the result was not interesting
+    FAILED, // The fuzz test did something non-fatal that was wrong. This should be recorded as a failure.
+    INTERESTING; // The fuzz test did not fail but also did something interesting. This run should be recorded in the corpus
+
+    public static boolean Passed(FuzzResult r) {
+        return r != FAILED;
+    }
+
+}

--- a/tribble-core/src/main/java/org/catapult/sa/tribble/FuzzTest.java
+++ b/tribble-core/src/main/java/org/catapult/sa/tribble/FuzzTest.java
@@ -9,9 +9,9 @@ public interface FuzzTest {
     /**
      * Defines a fuzz test. The input data for the test will be passed in
      * @param data input bytes for this test.
-     * @return return true if this is a successful test result or false if not.
+     * @return return FuzzResult describing this result.
      * @throws Exception if there is any problem with the test case. Any exceptions thrown out of the test case are
      * considered to be failures.
      */
-    boolean test(byte[] data) throws Exception;
+    FuzzResult test(byte[] data) throws Exception;
 }

--- a/tribble-test/src/main/scala/org/catapult/sa/testcase/TestCase.scala
+++ b/tribble-test/src/main/scala/org/catapult/sa/testcase/TestCase.scala
@@ -1,21 +1,21 @@
 package org.catapult.sa.testcase
 
-import org.catapult.sa.tribble.FuzzTest
+import org.catapult.sa.tribble.{FuzzResult, FuzzTest}
 
 /**
   * Really simple stupid test case
   */
 class TestCase extends FuzzTest {
 
-  def test(data : Array[Byte]): Boolean = {
+  def test(data : Array[Byte]): FuzzResult = {
     println("Hello World!")
     Fish.wibble(data)
 
     if (!data.isEmpty && data(0) == 0x00) {
       println("bob")
-      return true
+      return FuzzResult.OK
     }
-    true
+    return FuzzResult.OK
   }
 }
 


### PR DESCRIPTION
Fix #46 

Swap the result of the fuzz test to be an enum. This allows us to force the recording of an input in the corpus if the code determines that it is interesting even if its not new code coverage.