### PR TITLE
fix 45 pretty printing of duration in the stats object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Any contributions no matter how small are always welcome. We welcome every thing
 documentation to new features or translations. 
 
 ## Short version
-Github fork, branch, and pull requests. Github issues. Travis CI. Bintray JCenter releases.
+Gradle build. Github fork, branch, and pull requests. Github issues. Travis CI. Bintray JCenter releases.
 
 If you didn't understand that; fantastic! We really want your help, read on to find out how.
 
@@ -50,3 +50,9 @@ When your ready:
 * Create a pull request.
 
 We will then review the changes and get back to you with any questions, or hopefully just approve it.
+
+## Building for different scala versions
+
+If you need a version of this library with a different scala dependency. You should only need to change the 
+`ext.scalaVersion` value in the `build.gradle` file and rebuild. Note we support as a base 2.11.7 so something will show
+ deprecated warnings in 2.12. Please make sure any changes to the code build against 2.11.7. 

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/Stats.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/Stats.scala
@@ -65,5 +65,31 @@ class Stats {
 }
 
 case class CurrentStats(runs : Long, fails : Long, timeouts : Long, paths : Int, totalTime : Long, averageTime : Long, minTime : Long, maxTime : Long) {
-  override def toString: String = s"runs: $runs fails: $fails timeouts: $timeouts paths: $paths total time: $totalTime average time: $averageTime min time: $minTime max time: $maxTime"
+  override def toString: String = {
+    val t = CurrentStats.formatDuration(totalTime)
+    val a = CurrentStats.formatDuration(averageTime)
+    val min = if (minTime == Long.MaxValue) "~" else CurrentStats.formatDuration(minTime)
+    val max = if (maxTime == Long.MinValue) "~" else CurrentStats.formatDuration(maxTime)
+    s"runs: $runs fails: $fails timeouts: $timeouts paths: $paths total time: $t average time: $a min time: $min max time: $max"
+  }
+
+
+}
+
+object CurrentStats {
+  // Java8 Time doesn't have a duration formatter. Blah
+  def formatDuration(d : Long) : String = {
+    if (d == 0) {
+      "0S"
+    } else {
+      val abs = Math.abs(d)
+      val seconds = abs / 1000
+      val millis = abs - (seconds * 1000)
+
+      ((if (seconds/3600 > 0) (seconds/3600) + "H " else "") +
+        (if ((seconds%3600)/60 > 0) (seconds%3600)/60 + "M " else "") +
+        (if (seconds%60 > 0) (seconds%60) + "S " else "") +
+        (if (millis > 0) millis + "s" else "")).trim
+    }
+  }
 }

--- a/tribble-core/src/test/scala/org/catapult/sa/tribble/TestStats.scala
+++ b/tribble-core/src/test/scala/org/catapult/sa/tribble/TestStats.scala
@@ -1,0 +1,30 @@
+package org.catapult.sa.tribble
+
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+  * Quick test of the duration formatting in stats.
+  */
+class TestStats {
+
+  val tests = List(
+    (0L, "0S"),
+    (45000L, "45S"),
+    (4500L, "4S 500s"),
+    (5L, "5s"),
+    (67000L, "1M 7S"),
+    (70230L, "1M 10S 230s"),
+    (3606000L, "1H 6S")
+  )
+
+  @Test
+  def runTests() : Unit = {
+    tests.zipWithIndex.foreach { t =>
+      val result = CurrentStats.formatDuration(t._1._1)
+
+      assertEquals(s"Wrong result for entry ${t._2}, input ${t._1._1}", t._1._2, result)
+    }
+  }
+
+}


### PR DESCRIPTION
fix #45 
pretty print duration in the stats output so they are not in milliseconds and hard for humans to read.