### PR TITLE
fix #68 and #69. Verbose option and error on maven run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ failed/
 ## Plugin-specific files:
 
 # IntelliJ
-/out/
+out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ command line.
 | count | --count | number of iterations to run. Number greater than zero for a limit | -1 |
 | ignoreClasses | | List of class prefixes e.g `org.apache.hadoop.` to ignore from coverage. This is useful if you find some classes are already loaded. | |
 | | --ignoreClasses | Comma Seperated list of class prefixes to ignore.  e.g `org.apache.hadoop.` | |
+| verbose | --verbose | Should verbose mutator stats be printed. | false |
 
 ## Where next?
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -11,6 +11,7 @@ This is mainly documented for my own sake. However it might leave some breadcrum
 * Create a release in Github with the name `v{current.version}`
 * Run the bintrayUpload task on the root project on your local machine. You will need to have `systemProp.BINTRAY_USER` 
 and `systemProp.BINTRAY_KEY` set in your local user gradle.properties DO NOT CHECK THIS IN
+* Log in to bintray and publish the two releases
 * Bump the version number and put the `-SNAPSHOT` extension back on. 
 * Bump the versions in the `README.md` file.
 * Create a pull request to update master with the new version number.

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/App.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/App.scala
@@ -13,6 +13,7 @@ object App extends Arguments {
   private val FAILED = "failed"
   private val COUNT = "count"
   private val IGNORECLASSES = "ignore"
+  private val VERBOSE = "verbose"
 
 
   override def allowedArgs(): List[Argument] = List(
@@ -22,7 +23,8 @@ object App extends Arguments {
     Argument(TIMEOUT, "1000"),
     Argument(COUNT, "-1"),
     Argument(TARGET_CLASS),
-    Argument(IGNORECLASSES)
+    Argument(IGNORECLASSES),
+    Argument(VERBOSE, "false", flag = true)
   )
 
   def main(args : Array[String]) : Unit = {
@@ -60,7 +62,8 @@ object App extends Arguments {
       arguments(IGNORECLASSES).split(","),
       arguments(THREAD_COUNT).toInt,
       arguments(TIMEOUT).toLong,
-      arguments(COUNT).toLong
+      arguments(COUNT).toLong,
+      arguments(VERBOSE).toBoolean
     )
 
     fuzzer.run(arguments(TARGET_CLASS), getClass.getClassLoader)

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/CoverageMemoryClassLoader.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/CoverageMemoryClassLoader.scala
@@ -156,7 +156,7 @@ object CoverageMemoryClassLoader {
     *
     * @param name class name to find
     * @param parent the class loader to use to find this class.
-    * @return Inputstream that you cna read the class from. Make sure you call close on this.
+    * @return Inputstream that you can read the class from. Make sure you call close on this.
     */
   def getClassStream(name : String, parent : ClassLoader) : InputStream = {
     val res =  name.replace('.', '/') + ".class"

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
@@ -21,7 +21,8 @@ class Fuzzer(corpusPath : String = "corpus",
              ignoreClasses : Array[String] = Array(),
              threadCount : Int = 2,
              timeout : Long = 1000L,
-             iterationCount : Long = -1) {
+             iterationCount : Long = -1,
+             printDetailedStats: Boolean = true) {
 
   val rand = new Random()
   // TODO: argument for seed? Pretty sure this isn't needed with the saving of inputs and stacktraces.
@@ -34,6 +35,11 @@ class Fuzzer(corpusPath : String = "corpus",
   }
 
   def run(targetName : String, cl : ClassLoader) : Unit = {
+
+    if (!Corpus.validateDirectories(corpusPath, failedPath)) {
+      return
+    }
+
     val coverageSet = new ConcurrentHashMap[String, Object]()
 
     val stats = new Stats()
@@ -68,7 +74,7 @@ class Fuzzer(corpusPath : String = "corpus",
 
     while(futures.exists(!_.isDone)) {
       pool.awaitTermination(5, TimeUnit.SECONDS)
-      System.err.println(stats.getStats)
+      System.err.println(stats.getStats(printDetailedStats))
     }
 
     val fails = futures.filter(_.get().isInstanceOf[Throwable])

--- a/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
+++ b/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
@@ -41,6 +41,10 @@ public class TribblePlugin extends AbstractMojo {
     @Parameter(property = "fuzztest.count", required = true, defaultValue = "-1")
     public long count;
 
+
+    @Parameter(property = "fuzztest.verbose", required = true, defaultValue = "true")
+    public boolean verbose;
+
     @Parameter(property = "fuzztest.ignoreClasses")
     public String[] ignoreClasses;
 
@@ -75,7 +79,7 @@ public class TribblePlugin extends AbstractMojo {
 
             Thread.currentThread().setContextClassLoader(projectRealm);
 
-            Fuzzer fuzzer = new Fuzzer(corpusPath, failedPath, ignoreClasses, threads, timeout, count);
+            Fuzzer fuzzer = new Fuzzer(corpusPath, failedPath, ignoreClasses, threads, timeout, count, verbose);
             fuzzer.run(target, projectRealm);
 
         } catch (DuplicateRealmException | MalformedURLException e) {


### PR DESCRIPTION
Fixes #68 and #69 

Adds a check at the top of the run method of the fuzzer to validate the needed directories exist.
Adds a verbose flag to control output of the extra mutator stats.