### PR TITLE
include dependencies in maven poms

### DIFF
--- a/tribble-core/build.gradle
+++ b/tribble-core/build.gradle
@@ -67,12 +67,14 @@ bintray {
 publishing {
     publications {
         tribbleCorePub(MavenPublication) {
+            from components.java
             artifact jar
             artifact sourcesJar
             artifact javadocJar
             groupId project.group
             artifactId project.name
             version project.version
+
         }
     }
 }

--- a/tribble-maven-plugin/build.gradle
+++ b/tribble-maven-plugin/build.gradle
@@ -135,6 +135,7 @@ publishing {
             groupId project.group
             artifactId project.name
             version project.version
+            from components.java
         }
     }
 }


### PR DESCRIPTION
This should fix the maven poms to include the dependencies when downloaded from jcenter. Which they aren't currently. This is a problem.

Hopefully this should deal with #71 next time we do a release. Which should probably be sooner than later.