### PR TITLE
option to disable mutators

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ command line.
 | threads | --threads | Number of threads to use | 2 |
 | timeout | --timeout | Time out for an individual test run in milliseconds | 1000 |
 | count | --count | number of iterations to run. Number greater than zero for a limit | -1 |
+| verbose | --verbose | Should verbose mutator stats be printed. | false |
 | ignoreClasses | | List of class prefixes e.g `org.apache.hadoop.` to ignore from coverage. This is useful if you find some classes are already loaded. | |
 | | --ignoreClasses | Comma Seperated list of class prefixes to ignore.  e.g `org.apache.hadoop.` | |
-| verbose | --verbose | Should verbose mutator stats be printed. | false |
+| disabledMutators | | List of mutator class names to disable | |
+| | --disabledMutations | Comma seperated list of mutators to disable | |
 
 ## Where next?
 

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/App.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/App.scala
@@ -1,6 +1,7 @@
 package org.catapult.sa.tribble
 
 import org.apache.commons.lang.StringUtils
+import org.catapult.sa.tribble
 /**
  * Entry point for command line usage of the tribble fuzz testing tool.
  */
@@ -14,6 +15,7 @@ object App extends Arguments {
   private val COUNT = "count"
   private val IGNORECLASSES = "ignore"
   private val VERBOSE = "verbose"
+  private val DISABLED = "disabledMutations"
 
 
   override def allowedArgs(): List[Argument] = List(
@@ -24,7 +26,8 @@ object App extends Arguments {
     Argument(COUNT, "-1"),
     Argument(TARGET_CLASS),
     Argument(IGNORECLASSES),
-    Argument(VERBOSE, "false", flag = true)
+    Argument(VERBOSE, "false", flag = true),
+    Argument(DISABLED)
   )
 
   def main(args : Array[String]) : Unit = {
@@ -63,7 +66,8 @@ object App extends Arguments {
       arguments(THREAD_COUNT).toInt,
       arguments(TIMEOUT).toLong,
       arguments(COUNT).toLong,
-      arguments(VERBOSE).toBoolean
+      arguments(VERBOSE).toBoolean,
+      arguments(DISABLED).split(",")
     )
 
     fuzzer.run(arguments(TARGET_CLASS), getClass.getClassLoader)

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/Fuzzer.scala
@@ -22,7 +22,8 @@ class Fuzzer(corpusPath : String = "corpus",
              threadCount : Int = 2,
              timeout : Long = 1000L,
              iterationCount : Long = -1,
-             printDetailedStats: Boolean = true) {
+             printDetailedStats: Boolean = true,
+             disabledMutators: Array[String] = Array()) {
 
   val rand = new Random()
   // TODO: argument for seed? Pretty sure this isn't needed with the saving of inputs and stacktraces.
@@ -102,7 +103,7 @@ class Fuzzer(corpusPath : String = "corpus",
     var pathCountLastLoad = 0
     val obj = new Object() // don't create a new object for every entry in our hash "set"
 
-    val mutator = new PlugableMutationEngine(rand)
+    val mutator = new PlugableMutationEngine(rand, disabledMutators)
 
     while(countDown == null || countDown.getAndDecrement() > 0) {
 

--- a/tribble-core/src/main/scala/org/catapult/sa/tribble/PlugableMutationEngine.scala
+++ b/tribble-core/src/main/scala/org/catapult/sa/tribble/PlugableMutationEngine.scala
@@ -17,15 +17,17 @@ import scala.util.Random
   *
   * This should make it very easy to add new experimental mutation strategies
   */
-class PlugableMutationEngine(rand: Random) extends MutationEngine {
+class PlugableMutationEngine(rand: Random, disabledMutators : Array[String] = Array()) extends MutationEngine {
 
   private val mutators = findClasses()
   private val mutatorsNames = mutators.map(_.getClass.getSimpleName)
+
 
   private def findClasses(): List[Mutator] = {
     val classLoader = getClass.getClassLoader
     classLoader.getResources("org.catapult.sa.tribble.mutators")
       .flatMap(loadFile(_, classLoader))
+      .filterNot(c => disabledMutators.contains(c.getName))
       .map(_.newInstance())
       .toList
   }

--- a/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
+++ b/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
@@ -41,9 +41,11 @@ public class TribblePlugin extends AbstractMojo {
     @Parameter(property = "fuzztest.count", required = true, defaultValue = "-1")
     public long count;
 
-
     @Parameter(property = "fuzztest.verbose", required = true, defaultValue = "true")
     public boolean verbose;
+
+    @Parameter(property = "fuzztext.disabledMutators", required = true, defaultValue = "")
+    public String[] disabledMutators;
 
     @Parameter(property = "fuzztest.ignoreClasses")
     public String[] ignoreClasses;
@@ -79,7 +81,7 @@ public class TribblePlugin extends AbstractMojo {
 
             Thread.currentThread().setContextClassLoader(projectRealm);
 
-            Fuzzer fuzzer = new Fuzzer(corpusPath, failedPath, ignoreClasses, threads, timeout, count, verbose);
+            Fuzzer fuzzer = new Fuzzer(corpusPath, failedPath, ignoreClasses, threads, timeout, count, verbose, disabledMutators);
             fuzzer.run(target, projectRealm);
 
         } catch (DuplicateRealmException | MalformedURLException e) {

--- a/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
+++ b/tribble-maven-plugin/src/main/java/org/catapult/sa/TribblePlugin.java
@@ -44,7 +44,7 @@ public class TribblePlugin extends AbstractMojo {
     @Parameter(property = "fuzztest.verbose", required = true, defaultValue = "true")
     public boolean verbose;
 
-    @Parameter(property = "fuzztext.disabledMutators", required = true, defaultValue = "")
+    @Parameter(property = "fuzztest.disabledMutators", required = true, defaultValue = "")
     public String[] disabledMutators;
 
     @Parameter(property = "fuzztest.ignoreClasses")


### PR DESCRIPTION
Add option to disable mutators. This should be useful if there are mutators that never cause anything interesting to happen. This should make things more efficient if needed. Should fix #58 